### PR TITLE
Fix the undefined quote (which appeared as ? in the documentation )in…

### DIFF
--- a/dotnet/docfx/docs/getting-started.md
+++ b/dotnet/docfx/docs/getting-started.md
@@ -24,7 +24,7 @@ Before reading any operation can occur, the Reader.Open(IInputStream) method mus
 ```
 Note: You have to call reader.Open() before performing any read operations.
 
-With the Open-method, the caller has to pass in an object which implements the interface “IStream”. This object is used by the CZIReader in order to access the data in a CZI-file. With below methods can create input streams:
+With the Open-method, the caller has to pass in an object which implements the interface "IStream". This object is used by the CZIReader in order to access the data in a CZI-file. With below methods can create input streams:
 
 #### Open File using In-Memory Stream
 When the CZI file is already loaded in memory (e.g., from a bye array), it can be wrapped in an external input stream.


### PR DESCRIPTION
## Description
As shown in the picture, the quotes are shown as "?" in the documentation.
<img width="1223" height="337" alt="LibCZI_NET-PR11" src="https://github.com/user-attachments/assets/694094eb-15cb-46ef-afd7-6ce0aa1615e9" />

Fixes # (issue)
Replacing unsupported quotes with normal quotes.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Describe the tests that you ran to verify your changes.  
Provide instructions to reproduce.

## Checklist:

- [ ] I followed the Contributing Guidelines.
- [ ] I did a self-review.
- [ ] I commented my code, particularly in hard-to-understand areas.
- [ ] I updated the documentation.
- [ ] I updated the version of LibCZI_NET following [Versioning of LibCZI_NET](https://turbo-fiesta-krrk8qj.pages.github.io/LibCZI_Net/docs/building.html) depending on the [type of change](#type-of-change)
  - Bug fix -> PATCH
  - New feature -> MINOR
  - Breaking change -> MAJOR
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
